### PR TITLE
Read and transmit MifareType capability

### DIFF
--- a/src/main/java/com/fidesmo/fdsm/FidesmoCard.java
+++ b/src/main/java/com/fidesmo/fdsm/FidesmoCard.java
@@ -46,6 +46,7 @@ public class FidesmoCard {
     private byte[] cin = null;
     int platformVersion = 1;
     int platformType = 1;
+    int mifareType = 2;
 
     private FidesmoCard(CardChannel channel) {
         this.channel = channel;
@@ -129,6 +130,11 @@ public class FidesmoCard {
         if (platformVersionTag != null) {
             ByteBuffer platformValue = ByteBuffer.wrap(platformVersionTag.getBytesValue());
             platformVersion = platformValue.getInt();
+        }
+        BerTlv mifareTag = tlvs.find(new BerTag(0x42));
+        if (mifareTag != null) {
+            ByteBuffer mifareValue = ByteBuffer.wrap(mifareTag.getBytesValue());
+            mifareType = mifareValue.get(0);
         }
         BerTlv platformTypeTag = tlvs.find(new BerTag(0x45));
         if (platformTypeTag != null) {

--- a/src/main/java/com/fidesmo/fdsm/ServiceDeliverySession.java
+++ b/src/main/java/com/fidesmo/fdsm/ServiceDeliverySession.java
@@ -70,6 +70,7 @@ public class ServiceDeliverySession {
         // Capabilities, partial
         ObjectNode capabilities = JsonNodeFactory.instance.objectNode();
         capabilities.put("platformVersion", card.platformVersion);
+        capabilities.put("mifareType", card.mifareType);
         capabilities.put("osTypeVersion", card.platformType);
         capabilities.put("globalPlatformVersion", 0x0202); // Fixed to GlobalPlatform 2.2
         capabilities.put("jcVersion", 0x0300); // Fixed to JavaCard 3.0


### PR DESCRIPTION
Mifare services can only be delivered to devices having a Mifare emulation. The Fidesmo platform checks it by reading the device's capabilities before attempting to deliver the service.
This PR reads the Mifare Type tag (0x42) and sends it to the server in the delivery request, within the `capabilities` structure.