### PR TITLE
Fix --run detection and signal service status as process exit code

### DIFF
--- a/src/main/java/com/fidesmo/fdsm/CommandLineInterface.java
+++ b/src/main/java/com/fidesmo/fdsm/CommandLineInterface.java
@@ -170,14 +170,14 @@ abstract class CommandLineInterface {
 
     public static boolean requiresCard() {
         String[] commands = new String[]{
-                OPT_INSTALL, OPT_UNINSTALL, OPT_STORE_DATA, OPT_DELIVER, OPT_CARD_APPS, OPT_CARD_INFO, OPT_SECURE_APDU
+                OPT_INSTALL, OPT_UNINSTALL, OPT_STORE_DATA, OPT_SECURE_APDU, OPT_DELIVER, OPT_RUN, OPT_CARD_APPS, OPT_CARD_INFO
         };
         return Arrays.stream(commands).anyMatch(a -> args.has(a));
     }
 
     public static boolean requiresAuthentication() {
         String[] commands = new String[]{
-                OPT_INSTALL, OPT_UNINSTALL, OPT_STORE_DATA, OPT_SECURE_APDU, OPT_DELIVER, OPT_UPLOAD, OPT_DELETE_APPLET, OPT_FLUSH_APPLETS, OPT_CLEANUP, OPT_LIST_APPLETS, OPT_LIST_RECIPES
+                OPT_INSTALL, OPT_UNINSTALL, OPT_STORE_DATA, OPT_SECURE_APDU, OPT_UPLOAD, OPT_DELETE_APPLET, OPT_FLUSH_APPLETS, OPT_CLEANUP, OPT_LIST_APPLETS, OPT_LIST_RECIPES
         };
         return Arrays.stream(commands).anyMatch(a -> args.has(a));
     }

--- a/src/main/java/com/fidesmo/fdsm/Main.java
+++ b/src/main/java/com/fidesmo/fdsm/Main.java
@@ -238,7 +238,11 @@ public class Main extends CommandLineInterface {
                         fail("Need Application ID");
                     }
                     ServiceDeliverySession cardSession = ServiceDeliverySession.getInstance(fidesmoCard, client, formHandler);
-                    cardSession.deliver(appId, service);
+                    if (!cardSession.deliver(appId, service, System.out)) {
+                        fail("Failed to run service");
+                    } else {
+                        success(); // Explicitly quit to signal successful service. Which implies only one service per invocation
+                    }
                 } else if (requiresAuthentication()) { // XXX
                     AuthenticatedFidesmoApiClient client = getAuthenticatedClient();
                     FormHandler formHandler = getCommandLineFormHandler();


### PR DESCRIPTION
No fdsm will exit either 0 or 1 depending on successful or failing service run.

--run was added to command line interface, but ignored by internal logic. That is also fixed now.