### PR TITLE
bug: compare lower case reader name with lower case input argument

### DIFF
--- a/src/main/java/com/fidesmo/fdsm/Main.java
+++ b/src/main/java/com/fidesmo/fdsm/Main.java
@@ -175,7 +175,7 @@ public class Main extends CommandLineInterface {
                 if (args.has(OPT_READER)) {
                     String reader = args.valueOf(OPT_READER).toString();
                     for (CardTerminal t : TerminalManager.getTerminalFactory(null).terminals().list()) {
-                        if (t.getName().toLowerCase().contains(reader)) {
+                        if (t.getName().toLowerCase().contains(reader.toLowerCase())) {
                             terminal = t;
                         }
                     }


### PR DESCRIPTION
--reader is tailored for command line usage (which is usually lower case) but the input was not forced to be lower case. So a proper reader name copy-pasted would not match. That is now fixed