### PR TITLE
Preparations for next version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -307,7 +307,7 @@
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>findbugs-maven-plugin</artifactId>
-                <version>3.0.1</version>
+                <version>3.0.5</version>
                 <executions>
                     <execution>
                         <phase>verify</phase>

--- a/pom.xml
+++ b/pom.xml
@@ -6,10 +6,10 @@
 
     <groupId>com.fidesmo</groupId>
     <artifactId>fdsm</artifactId>
-    <version>19.03.06</version>
+    <version>19.03.29</version>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <project.version.windows>19.3.6.0</project.version.windows>
+        <project.version.windows>19.3.29.0</project.version.windows>
     </properties>
 
     <!-- Necessary metadata for Maven Central -->

--- a/pom.xml
+++ b/pom.xml
@@ -6,10 +6,10 @@
 
     <groupId>com.fidesmo</groupId>
     <artifactId>fdsm</artifactId>
-    <version>19.02.22</version>
+    <version>19.03.06</version>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <project.version.windows>19.2.22.0</project.version.windows>
+        <project.version.windows>19.3.6.0</project.version.windows>
     </properties>
 
     <!-- Necessary metadata for Maven Central -->
@@ -80,6 +80,12 @@
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
             <version>2.6</version>
+        </dependency>
+        <!-- Logging -->
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <version>1.7.25</version>
         </dependency>
         <!-- Simple logging for the CLI -->
         <dependency>

--- a/src/main/java/com/fidesmo/fdsm/AuthenticatedFidesmoApiClient.java
+++ b/src/main/java/com/fidesmo/fdsm/AuthenticatedFidesmoApiClient.java
@@ -34,16 +34,22 @@ import pro.javacard.CAPPackage;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.io.PrintStream;
 import java.net.URI;
 
 public class AuthenticatedFidesmoApiClient extends FidesmoApiClient {
-    private AuthenticatedFidesmoApiClient(String appId, String appKey) {
-        super(appId, appKey);
+    private AuthenticatedFidesmoApiClient(String appId, String appKey, PrintStream apidump) {
+        super(appId, appKey, apidump);
     }
 
     public static AuthenticatedFidesmoApiClient getInstance(String appId, String appKey) throws IllegalArgumentException {
-        return new AuthenticatedFidesmoApiClient(appId, appKey);
+        return new AuthenticatedFidesmoApiClient(appId, appKey, null);
     }
+
+    public static AuthenticatedFidesmoApiClient getInstance(String appId, String appKey, PrintStream apidump) throws IllegalArgumentException {
+        return new AuthenticatedFidesmoApiClient(appId, appKey, apidump);
+    }
+
 
     public void put(URI uri, String json) throws IOException {
         HttpPut put = new HttpPut(uri);

--- a/src/main/java/com/fidesmo/fdsm/CommandLineInterface.java
+++ b/src/main/java/com/fidesmo/fdsm/CommandLineInterface.java
@@ -59,6 +59,9 @@ abstract class CommandLineInterface {
     final static String OPT_VERBOSE = "verbose";
     final static String OPT_VERSION = "version";
 
+    final static String OPT_QA = "qa";
+    final static String OPT_TIMEOUT = "timeout";
+
     protected static String appId = null;
     protected static String appKey = null;
 
@@ -131,12 +134,15 @@ abstract class CommandLineInterface {
 
         parser.accepts(OPT_PARAMS, "Installation parameters").withRequiredArg().describedAs("HEX");
         parser.accepts(OPT_CREATE, "Applet instance AID").withRequiredArg().describedAs("AID");
-        parser.accepts(OPT_UNINSTALL, "Uninstall CAP from card").withRequiredArg().ofType(File.class).describedAs("CAP file");
+        parser.accepts(OPT_UNINSTALL, "Uninstall CAP from card").withRequiredArg().describedAs("CAP file / AID");
 
         parser.accepts(OPT_READER, "Specify reader to use").withRequiredArg().describedAs("reader");
         parser.accepts(OPT_TRACE_API, "Trace Fidesmo API");
         parser.accepts(OPT_TRACE_APDU, "Trace APDU-s");
         parser.accepts(OPT_VERBOSE, "Be verbose");
+
+        parser.accepts(OPT_QA, "Run a QA support session").withOptionalArg().ofType(Integer.class).describedAs("QA number");
+        parser.accepts(OPT_TIMEOUT, "Timeout for services").withRequiredArg().ofType(Integer.class).describedAs("minutes");
 
         parser.acceptsAll(Arrays.asList("V", OPT_VERSION), "Show version and check for updates");
 
@@ -172,7 +178,7 @@ abstract class CommandLineInterface {
 
     public static boolean requiresCard() {
         String[] commands = new String[]{
-                OPT_INSTALL, OPT_UNINSTALL, OPT_STORE_DATA, OPT_SECURE_APDU, OPT_DELIVER, OPT_RUN, OPT_CARD_APPS, OPT_CARD_INFO
+                OPT_INSTALL, OPT_UNINSTALL, OPT_STORE_DATA, OPT_SECURE_APDU, OPT_DELIVER, OPT_RUN, OPT_CARD_APPS, OPT_CARD_INFO, OPT_QA
         };
         return Arrays.stream(commands).anyMatch(a -> args.has(a));
     }

--- a/src/main/java/com/fidesmo/fdsm/FormHandler.java
+++ b/src/main/java/com/fidesmo/fdsm/FormHandler.java
@@ -4,6 +4,10 @@ import javax.security.auth.callback.CallbackHandler;
 import java.util.List;
 import java.util.Map;
 
+// Form handler should in the future be renamed to UI handler.
+// It fetches input from the user, based on a list of required fields.
+// It also implements javax.security callback handler to provide for input-output
+// from the mini-library in a "standard" way.
 public interface FormHandler extends CallbackHandler {
     Map<String, Field> processForm(List<Field> form);
 }

--- a/src/main/java/com/fidesmo/fdsm/FormHandler.java
+++ b/src/main/java/com/fidesmo/fdsm/FormHandler.java
@@ -1,8 +1,9 @@
 package com.fidesmo.fdsm;
 
+import javax.security.auth.callback.CallbackHandler;
 import java.util.List;
 import java.util.Map;
 
-public interface FormHandler {
+public interface FormHandler extends CallbackHandler {
     Map<String, Field> processForm(List<Field> form);
 }

--- a/src/main/java/com/fidesmo/fdsm/Main.java
+++ b/src/main/java/com/fidesmo/fdsm/Main.java
@@ -38,7 +38,6 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.PrintStream;
-import java.math.BigInteger;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.nio.file.Files;
@@ -50,6 +49,7 @@ import java.util.*;
 import java.util.stream.Collectors;
 
 public class Main extends CommandLineInterface {
+    static final String FDSM_SP = "8e5cdaae";
     private static FidesmoCard fidesmoCard;
 
     public static void main(String[] argv) {
@@ -229,7 +229,7 @@ public class Main extends CommandLineInterface {
                     ServiceDeliverySession cardSession = ServiceDeliverySession.getInstance(fidesmoCard, client, formHandler);
                     if (args.has(OPT_TIMEOUT))
                         cardSession.setTimeout((Integer) args.valueOf(OPT_TIMEOUT));
-                    if (!cardSession.deliver("8e5cdaae", number)) {
+                    if (!cardSession.deliver(FDSM_SP, number)) {
                         fail("Failed to run service");
                     } else {
                         success();

--- a/src/main/java/com/fidesmo/fdsm/Main.java
+++ b/src/main/java/com/fidesmo/fdsm/Main.java
@@ -38,8 +38,13 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.PrintStream;
+import java.math.BigInteger;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.nio.file.Files;
+import java.nio.file.NoSuchFileException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.security.GeneralSecurityException;
 import java.util.*;
 import java.util.stream.Collectors;
@@ -48,9 +53,20 @@ public class Main extends CommandLineInterface {
     private static FidesmoCard fidesmoCard;
 
     public static void main(String[] argv) {
+        System.setProperty("org.slf4j.simpleLogger.showThreadName", "false");
+        System.setProperty("org.slf4j.simpleLogger.levelInBrackets", "true");
+        System.setProperty("org.slf4j.simpleLogger.showShortLogName", "true");
+        System.setProperty("org.slf4j.simpleLogger.defaultLogLevel", "error");
+
         try {
             // Inspect arguments
             parseArguments(argv);
+            // Show useful stuff
+            if (args.has(OPT_VERBOSE))
+                System.setProperty("org.slf4j.simpleLogger.defaultLogLevel", "info");
+
+            // Check environment
+            inspectEnvironment(args);
 
             // Check for version
             if (args.has(OPT_VERSION)) {
@@ -197,6 +213,28 @@ public class Main extends CommandLineInterface {
                     terminal = LoggingCardTerminal.getInstance(terminal);
                 }
                 Card card = terminal.connect("*");
+                // Allows to run with any card
+                if (args.has(OPT_QA)) {
+                    String number = Integer.toString(new Random().nextInt(900000) + 100000).substring(0, 6);
+                    if (args.valueOf(OPT_QA) != null) {
+                        number = args.valueOf(OPT_QA).toString();
+                    } else {
+                        System.out.printf("Your QA number is %s-%s%n", number.substring(0, 3), number.substring(3, 6));
+                    }
+                    fidesmoCard = FidesmoCard.fakeInstance(card.getBasicChannel());
+                    FidesmoApiClient client = getClient();
+                    checkVersions(client);
+                    FormHandler formHandler = getCommandLineFormHandler();
+
+                    ServiceDeliverySession cardSession = ServiceDeliverySession.getInstance(fidesmoCard, client, formHandler);
+                    if (args.has(OPT_TIMEOUT))
+                        cardSession.setTimeout((Integer) args.valueOf(OPT_TIMEOUT));
+                    if (!cardSession.deliver("8e5cdaae", number)) {
+                        fail("Failed to run service");
+                    } else {
+                        success();
+                    }
+                }
                 fidesmoCard = FidesmoCard.getInstance(card.getBasicChannel());
                 System.out.println("Using card in " + terminal.getName());
 
@@ -209,7 +247,7 @@ public class Main extends CommandLineInterface {
                             fidesmoCard.getUID().map(i -> HexUtils.bin2hex(i)).orElse("N/A"),
                             showIIN ? String.format(" IIN: %s", HexUtils.bin2hex(fidesmoCard.getIIN())) : "");
                     // For platforms that are not yet supported by fdsm
-                    String platform = FidesmoCard.ChipPlatform.valueOf(fidesmoCard.platformType).orElseThrow(() -> new NotSupportedException("Chip platform not supported")).toString();
+                    String platform = FidesmoCard.ChipPlatform.valueOf(fidesmoCard.platformType).toString();
                     System.out.format("OS type: %s (platfrom v%d)%n", platform, fidesmoCard.platformVersion);
                 }
 
@@ -246,7 +284,9 @@ public class Main extends CommandLineInterface {
                         fail("Need Application ID");
                     }
                     ServiceDeliverySession cardSession = ServiceDeliverySession.getInstance(fidesmoCard, client, formHandler);
-                    if (!cardSession.deliver(appId, service, System.out)) {
+                    if (args.has(OPT_TIMEOUT))
+                        cardSession.setTimeout((Integer) args.valueOf(OPT_TIMEOUT));
+                    if (!cardSession.deliver(appId, service)) {
                         fail("Failed to run service");
                     } else {
                         success(); // Explicitly quit to signal successful service. Which implies only one service per invocation
@@ -286,17 +326,26 @@ public class Main extends CommandLineInterface {
                         }
                         fidesmoCard.deliverRecipe(client, formHandler, recipe);
                     } else if (args.has(OPT_UNINSTALL)) {
-                        CAPFile cap = CAPFile.fromStream(new FileInputStream((File) args.valueOf(OPT_UNINSTALL)));
-                        String recipe = RecipeGenerator.makeDeleteRecipe(cap.getPackageAID());
+                        String s = (String) args.valueOf(OPT_UNINSTALL);
+                        Path p = Paths.get(s);
+
+                        AID aid = null;
+                        if (!Files.exists(p)) {
+                            try {
+                                aid = AID.fromString(s);
+                            } catch (IllegalArgumentException e) {
+                                fail("Not a file or AID: " + s);
+                            }
+                        } else {
+                            aid = CAPFile.fromBytes(Files.readAllBytes(p)).getPackageAID();
+                        }
+                        String recipe = RecipeGenerator.makeDeleteRecipe(aid);
                         fidesmoCard.deliverRecipe(client, formHandler, recipe);
                     }
 
                     // Can be chained
                     if (args.has(OPT_STORE_DATA)) {
-                        List<byte[]> blobs = new ArrayList<>();
-                        for (Object s : args.valuesOf(OPT_STORE_DATA)) {
-                            blobs.add(HexUtils.stringToBin((String) s));
-                        }
+                        List<byte[]> blobs = args.valuesOf(OPT_STORE_DATA).stream().map(s -> HexUtils.stringToBin((String) s)).collect(Collectors.toList());
                         AID applet = AID.fromString(args.valueOf(OPT_APPLET).toString());
                         String recipe = RecipeGenerator.makeStoreDataRecipe(applet, blobs);
                         fidesmoCard.deliverRecipe(client, formHandler, recipe);
@@ -304,10 +353,7 @@ public class Main extends CommandLineInterface {
 
                     // Can be chained
                     if (args.has(OPT_SECURE_APDU)) {
-                        List<byte[]> apdus = new ArrayList<>();
-                        for (Object s : args.valuesOf(OPT_SECURE_APDU)) {
-                            apdus.add(HexUtils.stringToBin((String) s));
-                        }
+                        List<byte[]> apdus = args.valuesOf(OPT_SECURE_APDU).stream().map(s -> HexUtils.stringToBin((String) s)).collect(Collectors.toList());
                         AID applet = AID.fromString(args.valueOf(OPT_APPLET).toString());
                         String recipe = RecipeGenerator.makeSecureTransceiveRecipe(applet, apdus);
                         fidesmoCard.deliverRecipe(client, formHandler, recipe);
@@ -320,6 +366,8 @@ public class Main extends CommandLineInterface {
             fail("Not supported: " + e.getMessage());
         } catch (HttpResponseException e) {
             fail("API error: " + e.getMessage());
+        } catch (NoSuchFileException e) {
+            fail("No such file: " + e.getMessage());
         } catch (IOException e) {
             fail("I/O error: " + e.getMessage());
         } catch (CardException e) {
@@ -390,11 +438,7 @@ public class Main extends CommandLineInterface {
     }
 
     private static FidesmoApiClient getClient() {
-        FidesmoApiClient client = new FidesmoApiClient();
-        if (apiTrace) {
-            client.setTrace(true);
-        }
-        return client;
+        return new FidesmoApiClient(apiTrace ? System.out : null);
     }
 
     static void checkVersions(FidesmoApiClient client) {
@@ -435,16 +479,10 @@ public class Main extends CommandLineInterface {
     }
 
     private static AuthenticatedFidesmoApiClient getAuthenticatedClient() {
-        // Check environment
-        inspectEnvironment(args);
         if (appId == null || appKey == null) {
             fail("Provide appId and appKey, either via --app-id and --app-key or $FIDESMO_APP_ID and $FIDESMO_APP_KEY");
         }
-        AuthenticatedFidesmoApiClient client = AuthenticatedFidesmoApiClient.getInstance(appId, appKey);
-        if (apiTrace) {
-            client.setTrace(true);
-        }
-        return client;
+        return AuthenticatedFidesmoApiClient.getInstance(appId, appKey, apiTrace ? System.out : null);
     }
 
     private static class FidesmoService {


### PR DESCRIPTION
- Make use of CallbackHandlers and Logger from ServiceDeliverySession
- Allow to specify the output stream where FidesmoApiClient trace is written to
- Introduce timeouts and retries to service delivery (default is 10 minutes)
- Make FormHandler also implement CallbackHandler
- Introduce a special --qa argument and ability to fake a Fidesmo card