### PR TITLE
adds support of paid services redelivery

### DIFF
--- a/src/main/java/com/fidesmo/fdsm/FidesmoApiClient.java
+++ b/src/main/java/com/fidesmo/fdsm/FidesmoApiClient.java
@@ -57,6 +57,7 @@ public class FidesmoApiClient {
     public static final String APP_SERVICES_URL = "apps/%s/services";
 
     public static final String SERVICE_URL = "apps/%s/services/%s";
+    public static final String SERVICE_FOR_CARD_URL = "apps/%s/services/%s?cin=%s";
     public static final String SERVICE_RECIPE_URL = "apps/%s/services/%s/recipe";
     public static final String RECIPE_SERVICES_URL = "apps/%s/recipe-services";
 

--- a/src/main/java/com/fidesmo/fdsm/ServiceDeliverySession.java
+++ b/src/main/java/com/fidesmo/fdsm/ServiceDeliverySession.java
@@ -82,7 +82,7 @@ public class ServiceDeliverySession {
         client.rpc(client.getURI(FidesmoApiClient.DEVICES_URL, HexUtils.bin2hex(card.getCIN()), new BigInteger(1, card.getBatchId()).toString()));
 
         // Query service parameters
-        JsonNode service = client.rpc(client.getURI(FidesmoApiClient.SERVICE_URL, appId, serviceId), null);
+        JsonNode service = client.rpc(client.getURI(FidesmoApiClient.SERVICE_FOR_CARD_URL, appId, serviceId, HexUtils.bin2hex(card.getCIN())), null);
 
         // We do not support paid services
         if (service.has("price")) {


### PR DESCRIPTION
When doing a delivery it is advised to provide CIN of the card to service, that allows to properly compute price for specific card and allow redelivery in FDSM if it's free.