### PR TITLE
slow providers support added

### DIFF
--- a/src/main/java/com/fidesmo/fdsm/FidesmoApiClient.java
+++ b/src/main/java/com/fidesmo/fdsm/FidesmoApiClient.java
@@ -191,8 +191,6 @@ public class FidesmoApiClient {
         }
     }
 
-
-
     public URI getURI(String template, String... args) {
         try {
             return new URI(String.format(apiurl + template, args));

--- a/src/main/java/com/fidesmo/fdsm/FidesmoApiClient.java
+++ b/src/main/java/com/fidesmo/fdsm/FidesmoApiClient.java
@@ -147,6 +147,10 @@ public class FidesmoApiClient {
     }
 
     public JsonNode rpc(URI uri, JsonNode request) throws IOException {
+        return rpc(uri, request, 5);
+    }
+
+    public JsonNode rpc(URI uri, JsonNode request, int retries) throws IOException {
         final HttpRequestBase req;
         if (request != null) {
             HttpPost post = new HttpPost(uri);
@@ -167,14 +171,27 @@ public class FidesmoApiClient {
         req.setHeader("Content-type", ContentType.APPLICATION_JSON.toString());
 
         try (CloseableHttpResponse response = transmit(req)) {
-            JsonNode json = mapper.readTree(response.getEntity().getContent());
-            if (apidump != null) {
-                apidump.println("RECV:");
-                apidump.println(mapper.writer(printer).writeValueAsString(json));
+            if (response.getStatusLine().getStatusCode() == 204 && retries > 0) {
+                // response is not ready, retry after timeout
+                try {
+                    Thread.sleep(500);
+                } catch (InterruptedException iex) {
+                    throw new IOException("Thread was interrupted", iex);
+                }
+                return rpc(uri, request, retries - 1);
+            } else {
+                JsonNode json = mapper.readTree(response.getEntity().getContent());
+                if (apidump != null) {
+                    apidump.println("RECV:");
+                    apidump.println(mapper.writer(printer).writeValueAsString(json));
+                }
+
+                return json;
             }
-            return json;
         }
     }
+
+
 
     public URI getURI(String template, String... args) {
         try {


### PR DESCRIPTION
In case the service provider is slow sec-server can return `204` status for some commands, which requires retry from the client. Limited to a sane number of retries and timeout. 