### PR TITLE
Web socket support

### DIFF
--- a/library/pom.xml
+++ b/library/pom.xml
@@ -34,6 +34,11 @@
             <artifactId>httpclient</artifactId>
             <version>4.5.10</version>
         </dependency>
+        <dependency>
+            <groupId>org.java-websocket</groupId>
+            <artifactId>Java-WebSocket</artifactId>
+            <version>1.5.1</version>
+        </dependency>
         <!-- API access: JSON -->
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>

--- a/library/src/main/java/com/fidesmo/fdsm/AuthenticatedFidesmoApiClient.java
+++ b/library/src/main/java/com/fidesmo/fdsm/AuthenticatedFidesmoApiClient.java
@@ -38,18 +38,22 @@ import java.io.PrintStream;
 import java.net.URI;
 
 public class AuthenticatedFidesmoApiClient extends FidesmoApiClient {
-    private AuthenticatedFidesmoApiClient(String appId, String appKey, PrintStream apidump) {
-        super(appId, appKey, apidump);
+
+    private AuthenticatedFidesmoApiClient(ClientAuthentication auth, PrintStream apidump) {
+        super(auth, apidump);
     }
 
-    public static AuthenticatedFidesmoApiClient getInstance(String appId, String appKey) throws IllegalArgumentException {
-        return new AuthenticatedFidesmoApiClient(appId, appKey, null);
+    public static AuthenticatedFidesmoApiClient getInstance(String user, String password) throws IllegalArgumentException {
+        return new AuthenticatedFidesmoApiClient(ClientAuthentication.forUserPassword(user, password), null);
     }
 
-    public static AuthenticatedFidesmoApiClient getInstance(String appId, String appKey, PrintStream apidump) throws IllegalArgumentException {
-        return new AuthenticatedFidesmoApiClient(appId, appKey, apidump);
+    public static AuthenticatedFidesmoApiClient getInstance(String user, String password, PrintStream apidump) throws IllegalArgumentException {
+        return new AuthenticatedFidesmoApiClient(ClientAuthentication.forUserPassword(user, password), apidump);
     }
 
+    public static AuthenticatedFidesmoApiClient getInstance(ClientAuthentication auth, PrintStream apidump) throws IllegalArgumentException {
+        return new AuthenticatedFidesmoApiClient(auth, apidump);
+    }
 
     public void put(URI uri, String json) throws IOException {
         HttpPut put = new HttpPut(uri);
@@ -62,10 +66,10 @@ public class AuthenticatedFidesmoApiClient extends FidesmoApiClient {
         transmit(delete).close();
     }
 
+    @Deprecated
     public String getAppId() {
-        return appId;
+        return authentication.getUsername();
     }
-
 
     // Upload a CAP file
     public void upload(CAPFile cap) throws IOException {

--- a/library/src/main/java/com/fidesmo/fdsm/ClientAuthentication.java
+++ b/library/src/main/java/com/fidesmo/fdsm/ClientAuthentication.java
@@ -1,0 +1,59 @@
+package com.fidesmo.fdsm;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+
+public class ClientAuthentication {
+    private final String authentication;
+
+    private ClientAuthentication(String auth) {
+        if (auth.split(":").length > 2) {
+            throw new IllegalArgumentException("Wrong authentication format");
+        }
+        this.authentication = auth;
+    }
+
+    public boolean isToken() {
+        return !isCredentials();
+    }
+
+    public boolean isCredentials() {
+        return authentication.contains(":");
+    }
+
+    public String getUsername() {
+        if (!isCredentials()) return null;
+        return authentication.split(":")[0];
+    }
+
+    public static ClientAuthentication forToken(String token) {
+        return new ClientAuthentication(token);
+    }
+
+    public static ClientAuthentication forUserPassword(String user, String password) {
+        if (user == null || user.isEmpty()) {
+            throw new IllegalArgumentException("Username is not set");
+        }
+        if (password == null || password.isEmpty()) {
+            throw new IllegalArgumentException("Password is not set");
+        }
+        return new ClientAuthentication(user + ":" + password);
+    }
+
+    public static ClientAuthentication forUserPasswordOrToken(String auth) {
+        if (auth.contains(":")) {
+            String[] creds = auth.split(":");
+            return forUserPassword(creds[0], creds[1]);
+        } else {
+            return forToken(auth);
+        }
+    }
+
+    public String toAuthenticationHeader() {
+        if (isToken()) {
+            return "Bearer " + authentication;
+        } else {
+            return "Basic" + Base64.getEncoder().encodeToString(authentication.getBytes(StandardCharsets.UTF_8));
+        }
+    }
+}

--- a/library/src/main/java/com/fidesmo/fdsm/ClientAuthentication.java
+++ b/library/src/main/java/com/fidesmo/fdsm/ClientAuthentication.java
@@ -43,6 +43,9 @@ public class ClientAuthentication {
     public static ClientAuthentication forUserPasswordOrToken(String auth) {
         if (auth.contains(":")) {
             String[] creds = auth.split(":");
+            if (creds.length != 2) {
+                throw new IllegalArgumentException("Invalid user name and password format");
+            }
             return forUserPassword(creds[0], creds[1]);
         } else {
             return forToken(auth);

--- a/library/src/main/java/com/fidesmo/fdsm/FidesmoCard.java
+++ b/library/src/main/java/com/fidesmo/fdsm/FidesmoCard.java
@@ -151,18 +151,36 @@ public class FidesmoCard {
         return card;
     }
 
-    public boolean deliverRecipe(AuthenticatedFidesmoApiClient client, FormHandler formHandler, String recipe) throws CardException, IOException, UnsupportedCallbackException {
-        return deliverRecipes(client, formHandler, Collections.singletonList(recipe));
+
+    /**
+     * Deprecated in favour of deliverRecipes(AuthenticatedFidesmoApiClient, FormHandler, String, List<String>)
+     */
+    @Deprecated()
+    public boolean deliverRecipe(AuthenticatedFidesmoApiClient client, FormHandler formHandler, String recipe) throws IOException {
+        return deliverRecipe(client, formHandler, client.getAppId(), recipe);
     }
 
-    public boolean deliverRecipes(AuthenticatedFidesmoApiClient client, FormHandler formHandler, List<String> recipes) throws CardException, IOException, UnsupportedCallbackException {
+    /**
+     * Deprecated in favour of deliverRecipes(AuthenticatedFidesmoApiClient, FormHandler, String, List<String>)
+     */
+    @Deprecated()
+    public boolean deliverRecipes(AuthenticatedFidesmoApiClient client, FormHandler formHandler, List<String> recipes) throws IOException {
+        return deliverRecipes(client, formHandler, client.getAppId(), recipes);
+    }
+
+    public boolean deliverRecipe(AuthenticatedFidesmoApiClient client, FormHandler formHandler, String appId, String recipe) throws IOException {
+        return deliverRecipes(client, formHandler, appId, Collections.singletonList(recipe));
+    }
+
+    public boolean deliverRecipes(AuthenticatedFidesmoApiClient client, FormHandler formHandler, String appId, List<String> recipes) throws IOException {
+
         for (String recipe : recipes) {
             final String uuid = UUID.randomUUID().toString();
 
-            URI uri = client.getURI(FidesmoApiClient.SERVICE_RECIPE_URL, client.getAppId(), uuid);
+            URI uri = client.getURI(FidesmoApiClient.SERVICE_RECIPE_URL, appId, uuid);
             client.put(uri, recipe);
 
-            ServiceDeliverySession session = ServiceDeliverySession.getInstance(this, client, client.getAppId(), uuid, formHandler);
+            ServiceDeliverySession session = ServiceDeliverySession.getInstance(this, client, appId, uuid, formHandler);
 
             // Remove
             session.cleanups.add(() -> {

--- a/library/src/main/java/com/fidesmo/fdsm/UserCancelledException.java
+++ b/library/src/main/java/com/fidesmo/fdsm/UserCancelledException.java
@@ -23,6 +23,7 @@ package com.fidesmo.fdsm;
 
 // Handy marker to indicate user cancellation (ctrl-c, ctrl-d, escape etc)
 public class UserCancelledException extends FDSMException {
+    private static final long serialVersionUID = 2997004052307228095L;
     UserCancelledException(String message) {
         super(message);
     }

--- a/library/src/main/java/com/fidesmo/fdsm/WsClient.java
+++ b/library/src/main/java/com/fidesmo/fdsm/WsClient.java
@@ -1,0 +1,176 @@
+/*
+ * Copyright (c) 2018 - present Fidesmo AB
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package com.fidesmo.fdsm;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
+import org.apache.commons.codec.DecoderException;
+import org.apache.commons.codec.binary.Hex;
+import org.apache.http.auth.UsernamePasswordCredentials;
+import org.java_websocket.client.WebSocketClient;
+import org.java_websocket.handshake.ServerHandshake;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Base64;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+
+import javax.smartcardio.CardException;
+
+public class WsClient {
+    private final static Logger logger = LoggerFactory.getLogger(WsClient.class);
+
+    private static final ObjectMapper mapper = new ObjectMapper();
+
+    private final URI uri;
+    private final Map<String, String> headers;
+    private final FidesmoCard card;
+    private final WebSocketClient client;
+    private final CompletableFuture<ServiceDeliverySession.DeliveryResult> deliveryResult = new CompletableFuture<>();
+    private String sessionId;
+
+    public WsClient(URI uri, FidesmoCard card, Optional<UsernamePasswordCredentials> credentials) {
+        this.uri = uri;
+        this.headers = credentials.map(creds -> Collections.singletonMap("Authorization", encodeCredentials(creds)))
+                .orElse(null);
+        this.card = card;
+        this.client = buildClient();
+    }
+
+    public static CompletableFuture<ServiceDeliverySession.DeliveryResult> execute(URI uri, FidesmoCard card,
+            Optional<UsernamePasswordCredentials> credentials) {
+        return new WsClient(uri, card, credentials).run();
+    }
+
+    protected WebSocketClient buildClient() {
+        return new WebSocketClient(uri, headers) {
+            public void onOpen(ServerHandshake handshake) {
+            }
+
+            @Override
+            public void onMessage(String data) {
+                try {
+                    processCommand(mapper.readTree(data));
+                } catch (IOException | DecoderException | CardException e) {
+                    
+                    logger.warn("Error during delivery", e);
+
+                    respondWithStatus("CLIENT_ERROR", Optional.of(e.getMessage()));
+
+                    deliveryResult.complete(new ServiceDeliverySession.DeliveryResult(sessionId, false, e.getMessage(), Optional.empty()));
+
+                    close();
+                }
+            }
+
+            @Override
+            public void onClose(int code, String reason, boolean remote) {
+                if (!deliveryResult.isDone()) {
+                    deliveryResult.completeExceptionally(new Exception(reason));
+                }
+            }
+
+            @Override
+            public void onError(Exception ex) {
+                logger.warn("Error during obtaining commands: ", ex);
+                deliveryResult.completeExceptionally(ex);
+            }
+        };
+
+    }
+
+    public CompletableFuture<ServiceDeliverySession.DeliveryResult> run() {
+        if (deliveryResult.isDone()) {
+            throw new IllegalStateException("WsClient is single-use!");
+        }
+
+        client.connect();
+        return deliveryResult;
+    }
+
+    protected void processCommand(JsonNode node) throws IOException, DecoderException, CardException {
+        switch (node.get("type").asText()) {
+            case "id":
+                sessionId = node.get("value").asText();
+                logger.info("Session ID: " + sessionId);
+                break;
+            case "commands":
+                List<String> responses = new ArrayList<>();
+
+                for (JsonNode jsonNode : node.get("commands")) {
+                    byte[] command = Hex.decodeHex(jsonNode.asText());
+                    responses.add(Hex.encodeHexString(card.transmit(command)));
+                }
+
+                ObjectNode res = JsonNodeFactory.instance.objectNode();
+                res.put("type", "responses");
+                res.set("responses", mapper.valueToTree(responses));
+                respond(res);
+                break;
+            case "status":
+                String code = node.get("code").asText();
+                String message = node.get("message").asText("");
+
+                deliveryResult.complete(
+                    new ServiceDeliverySession.DeliveryResult(sessionId, "OK".equals(code), message, Optional.empty())
+                );
+
+                client.close();
+
+                break;
+            default:
+                throw new IllegalArgumentException("Unsupported message type: " + node.get("type").asText());
+        }
+    }
+
+    protected void respondWithStatus(String code, Optional<String> message) {
+        try {
+            ObjectNode res = JsonNodeFactory.instance.objectNode();
+            res.put("type", "status");
+            res.put("code", code);
+            message.ifPresent(m -> res.put("message", m));
+            respond(res);
+        } catch (Exception ex) {
+            logger.warn("Failed to send ", ex);
+        }
+    }
+
+    protected void respond(ObjectNode node) throws JsonProcessingException {
+        client.send(mapper.writeValueAsString(node));
+    }
+
+    private String encodeCredentials(UsernamePasswordCredentials creds) {
+        return "Basic " + Base64.getEncoder().encodeToString((creds.getUserName() + ":" + creds.getPassword()).getBytes(StandardCharsets.UTF_8));
+    }
+}

--- a/tool/src/main/java/com/fidesmo/fdsm/CommandLineInterface.java
+++ b/tool/src/main/java/com/fidesmo/fdsm/CommandLineInterface.java
@@ -33,6 +33,7 @@ import java.util.Arrays;
 abstract class CommandLineInterface {
     final static String OPT_APP_ID = "app-id";
     final static String OPT_APP_KEY = "app-key";
+    final static String OPT_USER = "user";
     final static String OPT_APPLET = "applet";
     final static String OPT_DELIVER = "deliver";
     final static String OPT_RUN = "run";
@@ -115,6 +116,7 @@ abstract class CommandLineInterface {
         parser.acceptsAll(Arrays.asList("h", "?", "help"), "Shows this help").forHelp();
         parser.accepts(OPT_APP_ID, "Specify application ID").withRequiredArg().describedAs("HEX");
         parser.accepts(OPT_APP_KEY, "Specify application key").withRequiredArg().describedAs("HEX");
+        parser.accepts(OPT_USER, "Server user name and password").withRequiredArg().describedAs("user:password");
         parser.accepts(OPT_STORE_DATA, "STORE DATA to applet").withRequiredArg().describedAs("HEX");
         parser.accepts(OPT_APPLET, "Specify applet").requiredIf(OPT_STORE_DATA).withRequiredArg().describedAs("AID");
 

--- a/tool/src/main/java/com/fidesmo/fdsm/CommandLineInterface.java
+++ b/tool/src/main/java/com/fidesmo/fdsm/CommandLineInterface.java
@@ -33,7 +33,7 @@ import java.util.Arrays;
 abstract class CommandLineInterface {
     final static String OPT_APP_ID = "app-id";
     final static String OPT_APP_KEY = "app-key";
-    final static String OPT_USER = "user";
+    final static String OPT_AUTH = "auth";
     final static String OPT_APPLET = "applet";
     final static String OPT_DELIVER = "deliver";
     final static String OPT_RUN = "run";
@@ -116,7 +116,7 @@ abstract class CommandLineInterface {
         parser.acceptsAll(Arrays.asList("h", "?", "help"), "Shows this help").forHelp();
         parser.accepts(OPT_APP_ID, "Specify application ID").withRequiredArg().describedAs("HEX");
         parser.accepts(OPT_APP_KEY, "Specify application key").withRequiredArg().describedAs("HEX");
-        parser.accepts(OPT_USER, "Server user name and password").withRequiredArg().describedAs("user:password");
+        parser.accepts(OPT_AUTH, "Server user name and password or token").withRequiredArg().describedAs("user:password / token");
         parser.accepts(OPT_STORE_DATA, "STORE DATA to applet").withRequiredArg().describedAs("HEX");
         parser.accepts(OPT_APPLET, "Specify applet").requiredIf(OPT_STORE_DATA).withRequiredArg().describedAs("AID");
 


### PR DESCRIPTION
Fidesmo API now supports Web Sockets for certain operations (at the moment only APDU exchange). This PR adds support of running web socket operations using the same `run` command. 

Also as Fidesmo API now supports generic credentials and not only `appId/appKey` for authentication, it is proposed to add a new option `auth` (with `$FDSM_AUTH` env variable) and use it everywhere.

So the complete example of WS execution:

```
fdsm --trace-apdu --verbose --auth test:test --run ws://url
```
