### PR TITLE
Make FidesmoCard a purely metadata class

### DIFF
--- a/library/src/main/java/com/fidesmo/fdsm/AuthenticatedFidesmoApiClient.java
+++ b/library/src/main/java/com/fidesmo/fdsm/AuthenticatedFidesmoApiClient.java
@@ -99,7 +99,7 @@ public class AuthenticatedFidesmoApiClient extends FidesmoApiClient {
 
     private static boolean isJCOPX(CAPFile cap, String version) {
         AID jcop = new AID(HexUtils.hex2bin("D276000085494A434F5058"));
-        return cap.getImports().stream().filter(p -> p.getAid().equals(jcop) && p.getVersionString().equals(version)).findFirst().isPresent();
+        return cap.getImports().stream().anyMatch(p -> p.getAid().equals(jcop) && p.getVersionString().equals(version));
     }
 
     public static boolean isJCOP242R2(CAPFile cap) {

--- a/library/src/main/java/com/fidesmo/fdsm/ClientAuthentication.java
+++ b/library/src/main/java/com/fidesmo/fdsm/ClientAuthentication.java
@@ -1,3 +1,24 @@
+/*
+ * Copyright (c) 2018 - present Fidesmo AB
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
 package com.fidesmo.fdsm;
 
 import java.nio.charset.StandardCharsets;

--- a/library/src/main/java/com/fidesmo/fdsm/FDSMException.java
+++ b/library/src/main/java/com/fidesmo/fdsm/FDSMException.java
@@ -22,6 +22,7 @@
 package com.fidesmo.fdsm;
 
 public class FDSMException extends RuntimeException {
+    public static final long serialVersionUID = -8067674386438803572L;
     FDSMException(String message) {
         super(message);
     }

--- a/library/src/main/java/com/fidesmo/fdsm/FidesmoApiClient.java
+++ b/library/src/main/java/com/fidesmo/fdsm/FidesmoApiClient.java
@@ -138,8 +138,7 @@ public class FidesmoApiClient {
             post.setEntity(new ByteArrayEntity(mapper.writeValueAsBytes(request)));
             req = post;
         } else {
-            HttpGet get = new HttpGet(uri);
-            req = get;
+            req = new HttpGet(uri);
         }
 
         if (apidump != null) {
@@ -170,7 +169,7 @@ public class FidesmoApiClient {
 
     public URI getURI(String template, String... args) {
         try {
-            return new URI(String.format(apiurl + template, args));
+            return new URI(String.format(apiurl + template, (Object[]) args));
         } catch (URISyntaxException e) {
             throw new IllegalArgumentException("Invalid url: " + e.getMessage(), e);
         }

--- a/library/src/main/java/com/fidesmo/fdsm/FidesmoCard.java
+++ b/library/src/main/java/com/fidesmo/fdsm/FidesmoCard.java
@@ -39,8 +39,6 @@ public class FidesmoCard {
     private final static Logger logger = LoggerFactory.getLogger(FidesmoCard.class);
 
     public enum ChipPlatform {
-
-        UNKNOWN(0),
         JCOP242R1(1),
         JCOP242R2(2),
         JCOP3EMV(3),
@@ -54,12 +52,12 @@ public class FidesmoCard {
             this.v = v;
         }
 
-        public static ChipPlatform valueOf(int v) {
+        public static Optional<ChipPlatform> valueOf(int v) {
             for (ChipPlatform t : values()) {
                 if (t.v == v)
-                    return t;
+                    return Optional.of(t);
             }
-            return UNKNOWN;
+            return Optional.empty();
         }
     }
 
@@ -103,12 +101,12 @@ public class FidesmoCard {
     }
 
     // Given CPLC, detect the platform from enumeration
-    public static ChipPlatform detectPlatform(byte[] cplc) {
+    public static Optional<ChipPlatform> detectPlatform(byte[] cplc) {
         for (Map.Entry<byte[], ChipPlatform> e : CPLC_PLATFORMS.entrySet()) {
             if (Arrays.equals(e.getKey(), Arrays.copyOf(cplc, e.getKey().length)))
-                return e.getValue();
+                return Optional.of(e.getValue());
         }
-        return ChipPlatform.UNKNOWN;
+        return Optional.empty();
     }
 
     // Capabilities applet AID
@@ -182,10 +180,6 @@ public class FidesmoCard {
 
     public byte[] getBatchId() {
         return batchId.clone();
-    }
-
-    public ChipPlatform getPlatform() {
-        return detectPlatform(cplc);
     }
 
     public static Optional<FidesmoCard> detectPlatformV2(APDUBIBO channel) {

--- a/library/src/main/java/com/fidesmo/fdsm/NotSupportedException.java
+++ b/library/src/main/java/com/fidesmo/fdsm/NotSupportedException.java
@@ -23,6 +23,7 @@ package com.fidesmo.fdsm;
 
 // Handy marker to indicate that a given scenario is not supported by this application
 public class NotSupportedException extends FDSMException {
+    private static final long serialVersionUID = 1293821614457263879L;
     NotSupportedException(String message) {
         super(message);
     }

--- a/library/src/main/java/com/fidesmo/fdsm/RecipeGenerator.java
+++ b/library/src/main/java/com/fidesmo/fdsm/RecipeGenerator.java
@@ -104,7 +104,7 @@ public class RecipeGenerator {
         action.put("endpoint", "/secure-transceive");
         ObjectNode content = action.putObject("content");
         content.put("application", app.toString());
-        content.set("commands", mapper.valueToTree(apdus.stream().map(i -> HexUtils.bin2hex(i)).collect(Collectors.toList())));
+        content.set("commands", mapper.valueToTree(apdus.stream().map(HexUtils::bin2hex).collect(Collectors.toList())));
         actions.add(action);
 
         return r.toString();

--- a/library/src/test/java/com/fidesmo/fdsm/FidesmoCardTest.java
+++ b/library/src/test/java/com/fidesmo/fdsm/FidesmoCardTest.java
@@ -3,38 +3,35 @@ package com.fidesmo.fdsm;
 import org.apache.commons.codec.binary.Hex;
 import org.testng.annotations.Test;
 
-import javax.smartcardio.CardException;
-
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
 
 public class FidesmoCardTest {
 
     @Test
-    public void testOldStorageAppletSupport() throws CardException {
+    public void testOldStorageAppletSupport()  {
         TestChannel channel = TestChannel.fromStrings(
                 "6F108408A000000151000000A5049F6501FF9000",
-                "04132EDA3D5F809000",
                 "9F7F2A47906B644700E4D80300816500485399064800000000000000005758594E4E4E4E4E00000000000000009000",
                 "3D5F8004132EDA9000",
                 "42030000C7430602396818B7440203009000"
         );
 
-        FidesmoCard card = FidesmoCard.getInstance(channel);
+        FidesmoCard card = FidesmoCard.detect(channel).get();
         assertEquals(Hex.encodeHexString(card.getCIN()), "3d5f8004132eda");
         assertEquals(Hex.encodeHexString(card.getBatchId()), "0000c7");
     }
 
     @Test
-    public void testCorrectParsingCardInfo() throws CardException {
+    public void testCorrectParsingCardInfo()  {
         TestChannel channel = TestChannel.fromStrings(
                 "6F108408A000000151000000A5049F6501FF9000",
-                "042457DA3D5F809000",
                 "9F7F2A47906B644700E4D80300816501062899064800000000000000005758594E4E4E4E4E00000000000000009000",
                 "3D5F8004132EDA9000",
                 "420300008C4306023967FE8B419000"
         );
 
-        FidesmoCard card = FidesmoCard.getInstance(channel);
+        FidesmoCard card = FidesmoCard.detect(channel).get();
         assertEquals(Hex.encodeHexString(card.getCIN()), "3d5f8004132eda");
         assertEquals(Hex.encodeHexString(card.getBatchId()), "00008c");
     }

--- a/library/src/test/java/com/fidesmo/fdsm/TestChannel.java
+++ b/library/src/test/java/com/fidesmo/fdsm/TestChannel.java
@@ -1,53 +1,37 @@
 package com.fidesmo.fdsm;
 
+import apdu4j.BIBO;
 import org.apache.commons.codec.DecoderException;
 import org.apache.commons.codec.binary.Hex;
 
-import javax.smartcardio.*;
-import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.List;
 
-public class TestChannel extends CardChannel {
+public class TestChannel implements BIBO {
 
     private int nextResponse;
-    private List<ResponseAPDU> responses;
+    private List<byte[]> responses;
 
-    public TestChannel(List<ResponseAPDU> responses) {
+    public TestChannel(List<byte[]> responses) {
         this.responses = responses;
     }
 
     @Override
-    public Card getCard() {
-        return null;
-    }
-
-    @Override
-    public int getChannelNumber() {
-        return 0;
-    }
-
-    @Override
-    public ResponseAPDU transmit(CommandAPDU commandAPDU) {
+    public byte[] transceive(byte[] commandAPDU) {
         return responses.get(nextResponse++);
     }
 
     @Override
-    public int transmit(ByteBuffer byteBuffer, ByteBuffer byteBuffer1) {
-        ResponseAPDU resp = responses.get(nextResponse++);
-        byteBuffer1.put(resp.getBytes());
-        return resp.getBytes().length;
-    }
+    public void close() {
 
-    @Override
-    public void close() {}
+    }
 
     public static TestChannel fromStrings(String... responses) {
         try {
-            List<ResponseAPDU> apdus = new ArrayList<>();
+            List<byte[]> apdus = new ArrayList<>();
 
             for (String s : responses) {
-                apdus.add(new ResponseAPDU(Hex.decodeHex(s)));
+                apdus.add(Hex.decodeHex(s));
             }
 
             return new TestChannel(apdus);

--- a/tool/src/main/java/com/fidesmo/fdsm/CommandLineInterface.java
+++ b/tool/src/main/java/com/fidesmo/fdsm/CommandLineInterface.java
@@ -70,9 +70,7 @@ abstract class CommandLineInterface {
     final static protected OptionSpec<String> OPT_CREATE = parser.accepts("create", "Applet instance AID").withRequiredArg().describedAs("AID");
     final static protected OptionSpec<String> OPT_UNINSTALL = parser.accepts("uninstall", "Uninstall CAP from card").withRequiredArg().describedAs("CAP file / AID");
 
-
     final static protected OptionSpec<Integer> OPT_QA = parser.accepts("qa", "Run a QA support session").withOptionalArg().ofType(Integer.class).describedAs("QA number");
-    final static protected OptionSpec<Void> OPT_FAKE = parser.accepts("fake", "Fake Fidesmo metadata");
 
     final static protected OptionSpec<Integer> OPT_TIMEOUT = parser.accepts("timeout", "Timeout for services").withRequiredArg().ofType(Integer.class).describedAs("minutes");
 

--- a/tool/src/main/java/com/fidesmo/fdsm/Main.java
+++ b/tool/src/main/java/com/fidesmo/fdsm/Main.java
@@ -27,6 +27,7 @@ import apdu4j.HexUtils;
 import apdu4j.TerminalManager;
 import apdu4j.terminals.LoggingCardTerminal;
 import com.fasterxml.jackson.databind.JsonNode;
+import com.fidesmo.fdsm.FidesmoCard.ChipPlatform;
 import jnasmartcardio.Smartcardio;
 import org.apache.commons.codec.binary.Hex;
 import org.apache.http.client.HttpResponseException;
@@ -276,11 +277,10 @@ public class Main extends CommandLineInterface {
                             JsonNode capabilities = device.get("description").get("capabilities");
                             int platformVersion = capabilities.get("platformVersion").asInt();
                             int platformType = capabilities.get("osTypeVersion").asInt();
-
-                            System.out.format("IIN: %s %n",
-                                    verbose ? String.format(" IIN: %s", HexUtils.bin2hex(iin)) : "");
+                            if (verbose)
+                                System.out.format("IIN: %s%n", HexUtils.bin2hex(iin));
                             // For platforms that are not yet supported by fdsm
-                            String platform = FidesmoCard.ChipPlatform.valueOf(platformType).toString();
+                            String platform = ChipPlatform.valueOf(platformType).map(ChipPlatform::toString).orElse("unknown");
                             System.out.format("OS type: %s (platform v%d)%n", platform, platformVersion);
                         }
                     } else {


### PR DESCRIPTION
This makes the separation between Fidesmo metadata and transport mechanisms more clear, whereas existing layout a bit more messy. Removes the need for --fake.

Includes some style changes (Optional in arguments)