### PR TITLE
Using updated CAP management URLs

### DIFF
--- a/library/src/main/java/com/fidesmo/fdsm/AuthenticatedFidesmoApiClient.java
+++ b/library/src/main/java/com/fidesmo/fdsm/AuthenticatedFidesmoApiClient.java
@@ -62,14 +62,14 @@ public class AuthenticatedFidesmoApiClient extends FidesmoApiClient {
     }
 
     // Upload a CAP file
-    public void upload(CAPFile cap) throws IOException {
+    public void upload(String appId, CAPFile cap) throws IOException {
         Optional<String> javaCardVersion = cap.guessJavaCardVersion();
         List<String> unsupportedVersions = Arrays.asList("3.1.0");
         if (!javaCardVersion.isPresent() || unsupportedVersions.contains(javaCardVersion.get())) {
             throw new IOException("Fidesmo supports JavaCard up to version 3.0.5");
         }
 
-        HttpPost post = new HttpPost(getURI(ELF_URL));
+        HttpPost post = new HttpPost(getURI(CAPFILES_URL, appId));
         // Metadata headers
         post.setHeader("Java-Card-Version", cap.guessJavaCardVersion().get());
         // Do not send this info at this moment

--- a/library/src/main/java/com/fidesmo/fdsm/FidesmoApiClient.java
+++ b/library/src/main/java/com/fidesmo/fdsm/FidesmoApiClient.java
@@ -48,7 +48,7 @@ import java.util.Locale;
 import java.util.Map;
 
 public class FidesmoApiClient {
-    public static final String APIv2 = "https://api.fidesmo.com/v2/";
+    public static final String APIv2 = "https://api.fidesmo.com/";
 
     public static final String APPS_URL = "apps%s";
     public static final String APP_INFO_URL = "apps/%s";
@@ -59,8 +59,8 @@ public class FidesmoApiClient {
     public static final String SERVICE_RECIPE_URL = "apps/%s/services/%s/recipe";
     public static final String RECIPE_SERVICES_URL = "apps/%s/recipe-services";
 
-    public static final String ELF_URL = "executableLoadFiles";
-    public static final String ELF_ID_URL = "executableLoadFiles/%s";
+    public static final String CAPFILES_URL = "apps/%s/capfiles";
+    public static final String CAPFILES_ID_URL = "apps/%s/capfiles/%s";
 
     public static final String SERVICE_DELIVER_URL = "service/deliver";
     public static final String SERVICE_FETCH_URL = "service/fetch";

--- a/tool/src/main/java/com/fidesmo/fdsm/CommandLineInterface.java
+++ b/tool/src/main/java/com/fidesmo/fdsm/CommandLineInterface.java
@@ -72,7 +72,7 @@ abstract class CommandLineInterface {
     final static protected OptionSpec<String> OPT_UNINSTALL = parser.accepts("uninstall", "Uninstall CAP from card").withRequiredArg().describedAs("CAP file / AID");
 
     final static protected OptionSpec<String> OPT_APP_ID = parser.accepts("app-id", "Application identifier")
-                                                                .requiredIf(OPT_STORE_DATA, OPT_SECURE_APDU, OPT_UNINSTALL, OPT_INSTALL, OPT_UPLOAD, OPT_CLEANUP)
+                                                                .requiredIf(OPT_STORE_DATA, OPT_SECURE_APDU, OPT_UNINSTALL, OPT_INSTALL, OPT_UPLOAD, OPT_CLEANUP, OPT_LIST_APPLETS, OPT_FLUSH_APPLETS, OPT_DELETE_APPLET)
                                                                 .withRequiredArg().describedAs("appId");
     final static protected OptionSpec<Integer> OPT_QA = parser.accepts("qa", "Run a QA support session").withOptionalArg().ofType(Integer.class).describedAs("QA number");
 

--- a/tool/src/main/java/com/fidesmo/fdsm/Main.java
+++ b/tool/src/main/java/com/fidesmo/fdsm/Main.java
@@ -128,7 +128,7 @@ public class Main extends CommandLineInterface {
                         }
                     }
                     try {
-                        client.delete(client.getURI(FidesmoApiClient.ELF_ID_URL, id));
+                        client.delete(client.getURI(FidesmoApiClient.CAPFILES_ID_URL, getAppId(), id));
                         System.out.println(id + " deleted.");
                     } catch (HttpResponseException e) {
                         if (e.getStatusCode() == 404) {
@@ -140,7 +140,7 @@ public class Main extends CommandLineInterface {
 
                 // List applets
                 if (args.has(OPT_LIST_APPLETS)) {
-                    JsonNode applets = client.rpc(client.getURI(FidesmoApiClient.ELF_URL));
+                    JsonNode applets = client.rpc(client.getURI(FidesmoApiClient.CAPFILES_URL, getAppId()));
                     // Show applets, grouped by AID-s.
                     if (applets.size() > 0) {
                         Map<String, Map<String, String>> r = new HashMap<>();
@@ -211,12 +211,12 @@ public class Main extends CommandLineInterface {
                         client.put(uri, recipe);
                     } else {
                         CAPFile cap = CAPFile.fromStream(new FileInputStream(args.valueOf(OPT_UPLOAD)));
-                        client.upload(cap);
+                        client.upload(getAppId(), cap);
                     }
                 } else if (args.has(OPT_FLUSH_APPLETS)) {
-                    JsonNode applets = client.rpc(client.getURI(FidesmoApiClient.ELF_URL));
+                    JsonNode applets = client.rpc(client.getURI(FidesmoApiClient.CAPFILES_URL, getAppId()));
                     for (JsonNode e : applets) {
-                        client.delete(client.getURI(FidesmoApiClient.ELF_ID_URL, e.get("id").asText()));
+                        client.delete(client.getURI(FidesmoApiClient.CAPFILES_ID_URL, getAppId(), e.get("id").asText()));
                     }
                 }
             }
@@ -400,7 +400,7 @@ public class Main extends CommandLineInterface {
                             }
                         }
                         byte[] lfdbh = cap.getLoadFileDataHash("SHA-256");
-                        JsonNode applets = client.rpc(client.getURI(FidesmoApiClient.ELF_URL));
+                        JsonNode applets = client.rpc(client.getURI(FidesmoApiClient.CAPFILES_URL, getAppId()));
                         boolean present = false;
                         for (JsonNode e : applets) {
                             if (Arrays.equals(Hex.decodeHex(e.get("id").asText()), lfdbh)) {
@@ -409,7 +409,7 @@ public class Main extends CommandLineInterface {
                         }
                         // Upload
                         if (!present) {
-                            authenticatedClient.upload(cap);
+                            authenticatedClient.upload(getAppId(), cap);
                         }
                         ObjectNode recipe = RecipeGenerator.makeInstallRecipe(lfdbh, applet, instance, params);
                         FidesmoCard.deliverRecipe(bibo, fidesmoCard, authenticatedClient, formHandler, getAppId(), recipe);


### PR DESCRIPTION
* Migrated to new CAP management endpoints that requires appId explicitly
* Removed `/v2/` prefix as now both versions are compatible, so prefix is not necessary.