### PR TITLE
Devices batching support added

### DIFF
--- a/library/src/main/java/com/fidesmo/fdsm/DeliveryUrl.java
+++ b/library/src/main/java/com/fidesmo/fdsm/DeliveryUrl.java
@@ -1,0 +1,71 @@
+package com.fidesmo.fdsm;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.Optional;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class DeliveryUrl {
+
+  private static final Pattern URI_PATH_PATTERN = Pattern.compile("/(\\w+)/services/(.*)");
+
+  private final Optional<String> appId;
+  private final String service;
+  private final boolean webSocket;
+
+  public DeliveryUrl(Optional<String> appId, String service, boolean webSocket) {
+    this.appId = appId;
+    this.service = service;
+    this.webSocket = webSocket;
+  }
+
+  public Optional<String> getAppId() {
+    return appId;
+  }
+
+  public String getService() {
+    return service;
+  }
+
+  public boolean isWebSocket() {
+    return webSocket;
+  }
+
+  /**
+   * Parses delivery parameters from the following representation forms:
+   * * :appId/:service - usual form used in --run command
+   * * https://apps.fidesmo.com/:appId/services/:service - web/mobile clients URL
+   * * ws:// or wss:// URL – Web socket URLs
+   */
+  public static DeliveryUrl parse(String deliveryString) {
+    try {
+      if (deliveryString.startsWith("https://") || deliveryString.startsWith("https://")) {
+        URI uri = new URI(deliveryString);
+        // Expected format is /{appId}/services/{service}
+        Matcher m = URI_PATH_PATTERN.matcher(uri.getPath());
+        if (m.matches()) {
+          return new DeliveryUrl(Optional.of(m.group(1)), m.group(2), false);
+        } else {
+          throw new IllegalArgumentException("Expected delivery string format is https://server/:appId/services/:service");
+        }      
+      } if (deliveryString.startsWith("wss://") || deliveryString.startsWith("ws://")) {
+        new URI(deliveryString); // validate a string is a proper URI
+        return new DeliveryUrl(Optional.empty(), deliveryString, true);
+      } else {
+        if (deliveryString.contains("/")) {
+          String[] bits = deliveryString.split("/");
+          if (bits.length == 2 && bits[0].length() == 8) {
+            return new DeliveryUrl(Optional.of(bits[0]), bits[1], false);
+          } else {
+            throw new IllegalArgumentException("Invalid format for service: " + deliveryString);
+          }        
+        } else {
+          return new DeliveryUrl(Optional.empty(), deliveryString, false);
+        }
+      }
+    } catch (URISyntaxException e) {
+      throw new IllegalArgumentException("Invalid URL syntax: " + e.getMessage());
+    }
+  }
+}

--- a/library/src/main/java/com/fidesmo/fdsm/DeliveryUrl.java
+++ b/library/src/main/java/com/fidesmo/fdsm/DeliveryUrl.java
@@ -40,7 +40,7 @@ public class DeliveryUrl {
    */
   public static DeliveryUrl parse(String deliveryString) {
     try {
-      if (deliveryString.startsWith("https://") || deliveryString.startsWith("https://")) {
+      if (deliveryString.startsWith("http://") || deliveryString.startsWith("https://")) {
         URI uri = new URI(deliveryString);
         // Expected format is /{appId}/services/{service}
         Matcher m = URI_PATH_PATTERN.matcher(uri.getPath());
@@ -52,17 +52,15 @@ public class DeliveryUrl {
       } if (deliveryString.startsWith("wss://") || deliveryString.startsWith("ws://")) {
         new URI(deliveryString); // validate a string is a proper URI
         return new DeliveryUrl(Optional.empty(), deliveryString, true);
-      } else {
-        if (deliveryString.contains("/")) {
-          String[] bits = deliveryString.split("/");
-          if (bits.length == 2 && bits[0].length() == 8) {
-            return new DeliveryUrl(Optional.of(bits[0]), bits[1], false);
-          } else {
-            throw new IllegalArgumentException("Invalid format for service: " + deliveryString);
-          }        
+      } else if (deliveryString.contains("/")) {
+        String[] bits = deliveryString.split("/");
+        if (bits.length == 2 && bits[0].length() == 8) {
+          return new DeliveryUrl(Optional.of(bits[0]), bits[1], false);
         } else {
-          return new DeliveryUrl(Optional.empty(), deliveryString, false);
-        }
+          throw new IllegalArgumentException("Invalid format for service: " + deliveryString);
+        }        
+      } else {
+        return new DeliveryUrl(Optional.empty(), deliveryString, false);
       }
     } catch (URISyntaxException e) {
       throw new IllegalArgumentException("Invalid URL syntax: " + e.getMessage());

--- a/library/src/main/java/com/fidesmo/fdsm/FidesmoApiClient.java
+++ b/library/src/main/java/com/fidesmo/fdsm/FidesmoApiClient.java
@@ -69,6 +69,7 @@ public class FidesmoApiClient {
     public static final String CONNECTOR_URL = "connector/json";
 
     public static final String DEVICES_URL = "devices/%s?batchId=%s";
+    public static final String DEVICE_IDENTIFY_URL = "devices/identify?cplc=%s";
 
     private PrintStream apidump;
     private final CloseableHttpClient http;
@@ -169,9 +170,9 @@ public class FidesmoApiClient {
         }
     }
 
-    public URI getURI(String template, String... args) {
+    public URI getURI(String template, Object... args) {
         try {
-            return new URI(String.format(apiurl + template, (Object[]) args));
+            return new URI(String.format(apiurl + template, args));
         } catch (URISyntaxException e) {
             throw new IllegalArgumentException("Invalid url: " + e.getMessage(), e);
         }

--- a/library/src/main/java/com/fidesmo/fdsm/FidesmoCard.java
+++ b/library/src/main/java/com/fidesmo/fdsm/FidesmoCard.java
@@ -22,16 +22,22 @@
 package com.fidesmo.fdsm;
 
 import apdu4j.core.*;
+
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.payneteasy.tlv.BerTag;
 import com.payneteasy.tlv.BerTlv;
 import com.payneteasy.tlv.BerTlvParser;
 import com.payneteasy.tlv.BerTlvs;
+
+import org.apache.commons.codec.DecoderException;
+import org.apache.commons.codec.binary.Hex;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import pro.javacard.AID;
 
 import java.io.IOException;
+import java.math.BigInteger;
 import java.net.URI;
 import java.util.*;
 
@@ -136,22 +142,33 @@ public class FidesmoCard {
 
     private final byte[] cin;
     private final byte[] cplc;
-    private final byte[] batchId;
+    private final int batchId;
+    /** Indicates that device is fully batched or requires batching operation otherwise */
+    private final boolean batched;
 
-    public FidesmoCard(byte[] fid, byte[] cplc, byte[] batchId) {
-        if (batchId == null) throw new NullPointerException("batch can't be null");
+    public FidesmoCard(byte[] fid, byte[] cplc, int batchId, boolean batched) {
         if (fid == null) throw new NullPointerException("fid can't be null");
         this.cin = fid.clone();
         this.cplc = cplc == null ? null : cplc.clone();
-        this.batchId = batchId.clone();
+        this.batchId = batchId;
+        this.batched = batched;
     }
 
     public static FidesmoCard dummy() {
-        return new FidesmoCard(new byte[7], null, new byte[4]);
+        return new FidesmoCard(new byte[7], null, 0, true);
     }
 
+    @Deprecated
     public static Optional<FidesmoCard> detect(BIBO channel) {
+        return detectOffline(channel);
+    }
+
+    public static Optional<FidesmoCard> detectOffline(BIBO channel) {
         return detect(probe(channel));
+    }
+
+    public static Optional<FidesmoCard> detectOnline(BIBO channel, FidesmoApiClient client) {
+        return detect(probe(channel), client);
     }
 
     static final HexBytes selectISD = HexBytes.b(new CommandAPDU(0x00, 0xA4, 0x04, 0x00, 0x00).getBytes());
@@ -208,6 +225,10 @@ public class FidesmoCard {
     }
 
     public static Optional<FidesmoCard> detect(Map<HexBytes, byte[]> commands) {
+        return detect(commands, null);
+    }
+
+    public static Optional<FidesmoCard> detect(Map<HexBytes, byte[]> commands, FidesmoApiClient client) {
         final byte[] cplc;
         final byte[] cin;
         final byte[] batch;
@@ -242,9 +263,27 @@ public class FidesmoCard {
 
         batch = pv3batch.orElseGet(() -> pv2batch.orElse(null));
 
-        if (cin == null || batch == null)
-            return Optional.empty();
-        return Optional.of(new FidesmoCard(cin, cplc, batch));
+        if (cin == null || batch == null) {
+            if (client == null) return Optional.empty();
+            
+            // Try to identify device on the server side using CPLC data
+            try {
+                JsonNode detect = client.rpc(client.getURI(FidesmoApiClient.DEVICE_IDENTIFY_URL, HexUtils.bin2hex(cplc)));
+                
+                if (detect != null) {
+                    // "batchingUrl" parameter is ignored for now
+                    byte[] fid = Hex.decodeHex(detect.get("cin").asText());
+                    int batchId = detect.get("batchId").asInt();
+                    return Optional.of(new FidesmoCard(fid, cplc, batchId, false));
+                }
+            } catch(DecoderException dex) {
+                throw new RuntimeException("Failed to decode FID from server: ", dex);
+            } catch(IOException ex) {
+                return Optional.empty();
+            }
+        }
+            
+        return Optional.of(new FidesmoCard(cin, cplc, new BigInteger(1, batch).intValue(), true));
     }
 
     public static boolean deliverRecipe(BIBO bibo, FidesmoCard card, AuthenticatedFidesmoApiClient
@@ -283,8 +322,12 @@ public class FidesmoCard {
         return cin.clone();
     }
 
-    public byte[] getBatchId() {
-        return batchId.clone();
+    public int getBatchId() {
+        return batchId;
+    }
+
+    public boolean isBatched() {
+        return batched;
     }
 
     public byte[] getCPLC() {

--- a/library/src/main/java/com/fidesmo/fdsm/FidesmoCard.java
+++ b/library/src/main/java/com/fidesmo/fdsm/FidesmoCard.java
@@ -271,7 +271,6 @@ public class FidesmoCard {
                 JsonNode detect = client.rpc(client.getURI(FidesmoApiClient.DEVICE_IDENTIFY_URL, HexUtils.bin2hex(cplc)));
                 
                 if (detect != null) {
-                    // "batchingUrl" parameter is ignored for now
                     byte[] fid = Hex.decodeHex(detect.get("cin").asText());
                     int batchId = detect.get("batchId").asInt();
                     return Optional.of(new FidesmoCard(fid, cplc, batchId, false));

--- a/library/src/main/java/com/fidesmo/fdsm/ServiceDeliverySession.java
+++ b/library/src/main/java/com/fidesmo/fdsm/ServiceDeliverySession.java
@@ -43,7 +43,6 @@ import javax.security.auth.callback.TextOutputCallback;
 import javax.security.auth.callback.UnsupportedCallbackException;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
-import java.math.BigInteger;
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.security.GeneralSecurityException;
@@ -107,7 +106,7 @@ public class ServiceDeliverySession implements Callable<ServiceDeliverySession.D
 
     public DeliveryResult deliver(BIBO bibo, String appId, String serviceId) throws IOException, UnsupportedCallbackException {
         // Address #4
-        JsonNode deviceInfo = client.rpc(client.getURI(FidesmoApiClient.DEVICES_URL, HexUtils.bin2hex(card.getCIN()), new BigInteger(1, card.getBatchId()).toString()));
+        JsonNode deviceInfo = client.rpc(client.getURI(FidesmoApiClient.DEVICES_URL, HexUtils.bin2hex(card.getCIN()), card.getBatchId()));
         byte[] iin = HexUtils.decodeHexString_imp(deviceInfo.get("iin").asText());
         JsonNode capabilities = deviceInfo.get("description").get("capabilities");
         int platformVersion = capabilities.get("platformVersion").asInt();

--- a/library/src/test/java/com/fidesmo/fdsm/DeliveryUrlTest.java
+++ b/library/src/test/java/com/fidesmo/fdsm/DeliveryUrlTest.java
@@ -1,0 +1,38 @@
+package com.fidesmo.fdsm;
+
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+
+import java.util.Optional;
+
+public class DeliveryUrlTest {
+
+    @Test
+    public void testAppIdServiceStringParsed() {
+        DeliveryUrl delivery = DeliveryUrl.parse("11223344/test-service-1");
+        assertEquals(delivery.getAppId(), Optional.of("11223344"));
+        assertEquals(delivery.getService(), "test-service-1");
+    }
+
+    @Test
+    public void testStagingDeliveryUrlParsed() {
+        DeliveryUrl delivery = DeliveryUrl.parse("https://apps-staging.fidesmo.com/ab11ffcc/services/test-service-2");
+        assertEquals(delivery.getAppId(), Optional.of("ab11ffcc"));
+        assertEquals(delivery.getService(), "test-service-2");
+    }
+    
+    @Test
+    public void testWebSockedUrlParsed() {
+        DeliveryUrl delivery = DeliveryUrl.parse("ws://test.fidesmo.com/path/test-service-3");
+        assertEquals(delivery.getAppId(), Optional.empty());
+        assertEquals(delivery.getService(), "ws://test.fidesmo.com/path/test-service-3");
+    }
+
+    @Test
+    public void testSecuredWebSockedUrlParsed() {
+        DeliveryUrl delivery = DeliveryUrl.parse("wss://test.fidesmo.com/path/test-service-4");
+        assertEquals(delivery.getAppId(), Optional.empty());
+        assertEquals(delivery.getService(), "wss://test.fidesmo.com/path/test-service-4");
+    }
+}

--- a/library/src/test/java/com/fidesmo/fdsm/FidesmoCardTest.java
+++ b/library/src/test/java/com/fidesmo/fdsm/FidesmoCardTest.java
@@ -17,9 +17,9 @@ public class FidesmoCardTest {
                 "42030000C7430602396818B7440203009000"
         );
 
-        FidesmoCard card = FidesmoCard.detect(channel).get();
+        FidesmoCard card = FidesmoCard.detectOffline(channel).get();
         assertEquals(Hex.encodeHexString(card.getCIN()), "3d5f8004132eda");
-        assertEquals(Hex.encodeHexString(card.getBatchId()), "0000c7");
+        assertEquals(card.getBatchId(), 199);
     }
 
     @Test
@@ -32,8 +32,8 @@ public class FidesmoCardTest {
                 "420300008C4306023967FE8B419000"
         );
 
-        FidesmoCard card = FidesmoCard.detect(channel).get();
+        FidesmoCard card = FidesmoCard.detectOffline(channel).get();
         assertEquals(Hex.encodeHexString(card.getCIN()), "3d5f8004132eda");
-        assertEquals(Hex.encodeHexString(card.getBatchId()), "00008c");
+        assertEquals(card.getBatchId(), 140);
     }
 }

--- a/tool/src/main/java/com/fidesmo/fdsm/CommandLineInterface.java
+++ b/tool/src/main/java/com/fidesmo/fdsm/CommandLineInterface.java
@@ -105,7 +105,9 @@ abstract class CommandLineInterface {
 
         // API URL
         try {
-            apiurl = new URL(System.getenv().getOrDefault(ENV_FIDESMO_API_URL, FidesmoApiClient.APIv2)).toString();
+            String url = new URL(System.getenv().getOrDefault(ENV_FIDESMO_API_URL, FidesmoApiClient.APIv2)).toString();
+            // normalize URL
+            apiurl = url.endsWith("/") ? url : url + "/";
         } catch (MalformedURLException e) {
             System.err.printf("Invalid $%s: %s%n", ENV_FIDESMO_API_URL, System.getenv(ENV_FIDESMO_API_URL));
         }


### PR DESCRIPTION
Adds ability to automatically batch devices post issuence.
How it works? 
* `FidesmoCard` now have online and offline device identification options, where online version tries to identify device by the CPLC data on the server as the last resort
* Implicit batching for operations that require a Fidesmo device, like installation, store-data etc
* On device info command we only print instructions of how to do batching manually without performing any changes

Other related changes:
* As `batchId` in the `FidesmoCard` can be obtained from the server it moved to integer, breaking change, but AFAIK it's only used internally and was always converted to int every time, so better to have it correct as soon as possible.
* Added a batched flag to the `FidesmoCard`.
* Added a `DeliveryUrl` parser, as it started to be used in multiple places
* Env variable normalisation: we expect an URL ending with `/` and if the variable specified without it client fails.
* Moved validation of the fidesmo device presence closer to the usage, as some operations allows chaining and it was throwing an error for instance if user obtains device information on non Fidesmo device 