### PR TITLE
Added UID for identifying unbatched device

### DIFF
--- a/library/src/main/java/com/fidesmo/fdsm/FidesmoApiClient.java
+++ b/library/src/main/java/com/fidesmo/fdsm/FidesmoApiClient.java
@@ -70,6 +70,7 @@ public class FidesmoApiClient {
 
     public static final String DEVICES_URL = "devices/%s?batchId=%s";
     public static final String DEVICE_IDENTIFY_URL = "devices/identify?cplc=%s";
+    public static final String DEVICE_IDENTIFY_WITH_UID_URL = "devices/identify?cplc=%s&uid=%s";
 
     private PrintStream apidump;
     private final CloseableHttpClient http;

--- a/library/src/main/java/com/fidesmo/fdsm/FidesmoCard.java
+++ b/library/src/main/java/com/fidesmo/fdsm/FidesmoCard.java
@@ -278,7 +278,7 @@ public class FidesmoCard {
             // Try to identify device on the server side using CPLC data
             try {
                 URI uri = uid
-                        .map(value -> client.getURI(FidesmoApiClient.DEVICE_IDENTIFY_WITH_UID_URL, HexUtils.bin2hex(cplc), value))
+                        .map(value -> client.getURI(FidesmoApiClient.DEVICE_IDENTIFY_WITH_UID_URL, HexUtils.bin2hex(cplc), HexUtils.bin2hex(value)))
                         .orElse(client.getURI(FidesmoApiClient.DEVICE_IDENTIFY_URL, HexUtils.bin2hex(cplc)));
                 JsonNode detect = client.rpc(uri);
                 

--- a/library/src/test/java/com/fidesmo/fdsm/FidesmoCardTest.java
+++ b/library/src/test/java/com/fidesmo/fdsm/FidesmoCardTest.java
@@ -10,6 +10,7 @@ public class FidesmoCardTest {
     @Test
     public void testOldStorageAppletSupport() {
         TestChannel channel = TestChannel.fromStrings(
+                "001122334455669000",
                 "6F108408A000000151000000A5049F6501FF9000",
                 "9F7F2A47906B644700E4D80300816500485399064800000000000000005758594E4E4E4E4E00000000000000009000",
                 "45073D5F8004132EDA9000",
@@ -25,6 +26,7 @@ public class FidesmoCardTest {
     @Test
     public void testCorrectParsingCardInfo() {
         TestChannel channel = TestChannel.fromStrings(
+                "001122334455669000",
                 "6F108408A000000151000000A5049F6501FF9000",
                 "9F7F2A47906B644700E4D80300816501062899064800000000000000005758594E4E4E4E4E00000000000000009000",
                 "45073D5F8004132EDA9000",

--- a/tool/src/main/java/com/fidesmo/fdsm/CommandLineInterface.java
+++ b/tool/src/main/java/com/fidesmo/fdsm/CommandLineInterface.java
@@ -77,6 +77,7 @@ abstract class CommandLineInterface {
     final static protected OptionSpec<Integer> OPT_QA = parser.accepts("qa", "Run a QA support session").withOptionalArg().ofType(Integer.class).describedAs("QA number");
 
     final static protected OptionSpec<Integer> OPT_TIMEOUT = parser.accepts("timeout", "Timeout for services").withRequiredArg().ofType(Integer.class).describedAs("minutes");
+    final static protected OptionSpec<Void> OPT_IGNORE_IMPLICIT_BATCHING = parser.accepts("ignore-implicit-batching", "Require explicit batching if not a Fidesmo device");
 
     final static String ENV_FIDESMO_API_URL = "FIDESMO_API_URL";
     final static String ENV_FIDESMO_AUTH = "FIDESMO_AUTH";
@@ -90,6 +91,7 @@ abstract class CommandLineInterface {
     protected static PrintStream apiTraceStream;
     protected static boolean verbose = false;
     protected static boolean offline = false;
+    protected static boolean ignoreImplicitBatching = false;
 
     protected static OptionSet args = null;
 
@@ -139,6 +141,7 @@ abstract class CommandLineInterface {
         apduTraceStream = args.has(OPT_TRACE_APDU) ? System.out : null;
         verbose = args.has(OPT_VERBOSE);
         offline = args.has(OPT_OFFLINE);
+        ignoreImplicitBatching = args.has(OPT_IGNORE_IMPLICIT_BATCHING);
         return args;
     }
 

--- a/tool/src/main/java/com/fidesmo/fdsm/Main.java
+++ b/tool/src/main/java/com/fidesmo/fdsm/Main.java
@@ -303,17 +303,10 @@ public class Main extends CommandLineInterface {
                             int platformVersion = capabilities.get("platformVersion").asInt();
                             String platform = Optional.ofNullable(capabilities.get("osTypeVersionName")).map(JsonNode::asText).orElse("unknown");
                             if (verbose)
-                                System.out.format("IIN: %s%n", HexUtils.bin2hex(iin));                            
+                                System.out.format("IIN: %s%n", HexUtils.bin2hex(iin));
                             System.out.format("OS type: %s (platform v%d)%n", platform, platformVersion);
 
-                            if (!fidesmoCard.isBatched()) {                                
-                                String batchingInstruction = getBatchingUrl(client, fidesmoCard.getCPLC(), fidesmoCard.getUID()).map(delivery -> {
-                                    String options = delivery.getAppId().map(appId -> String.format("%s/%s", appId, delivery.getService())).orElse(delivery.getService());
-                                    return String.format(". Use \"fdsm --run %s\" to complete batching procedure", options);                                    
-                                }).orElse(""); // batching procedure can't be completed
-                                
-                                System.out.println("Device is not batched" + batchingInstruction);
-                            }
+                            ensureBatched(bibo, client, fidesmoMetadata.get());
                         }
                     } else {
                         System.out.println("UID: " + uid.map(HexUtils::bin2hex).orElse("N/A"));

--- a/tool/src/main/java/com/fidesmo/fdsm/Main.java
+++ b/tool/src/main/java/com/fidesmo/fdsm/Main.java
@@ -573,7 +573,7 @@ public class Main extends CommandLineInterface {
     }
 
     private static FidesmoCard ensureBatched(APDUBIBO bibo, FidesmoApiClient client, FidesmoCard device) throws URISyntaxException, IOException {
-        if (!device.isBatched()) {
+        if (!device.isBatched() && !args.has(OPT_IGNORE_IMPLICIT_BATCHING)) {
             Optional<DeliveryUrl> deliveryOpt = getBatchingUrl(client, device.getCPLC(), device.getUID());
             if (deliveryOpt.isPresent()) {
                 DeliveryUrl delivery = deliveryOpt.get();


### PR DESCRIPTION
The UID is required for checking to which concrete UID-range belongs some batch that will be assigned to the device