### PR TITLE
Limit to 1 regex application while checking basic auth.

### DIFF
--- a/library/src/main/java/com/fidesmo/fdsm/ClientAuthentication.java
+++ b/library/src/main/java/com/fidesmo/fdsm/ClientAuthentication.java
@@ -62,7 +62,7 @@ public class ClientAuthentication {
 
     public static ClientAuthentication forUserPasswordOrToken(String auth) {
         if (auth.contains(":")) {
-            String[] creds = auth.split(":");
+            String[] creds = auth.split(":",2);
             if (creds.length != 2) {
                 throw new IllegalArgumentException("Invalid username and password format");
             }


### PR DESCRIPTION
If a password contains the character ":" right now we return an exception, according to [the Basic Auth Scheme](https://datatracker.ietf.org/doc/html/rfc7617) it should be allowed in password and not in username. Since we receive the auth string as a whole we have no way of knowing if many colons are intended or not.
We can simply assume the string is valid and limit the split to 1 parition ([.split() command](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/lang/String.html#split(java.lang.String,int)) limit parameter refers to the max number of resulting elements).
