### PR TITLE
Updated release and publishing config

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,7 +59,7 @@ jobs:
           gpg_private_key: ${{ secrets.OSSRH_GPG_SECRET_KEY }}
           passphrase: ${{ secrets.OSSRH_GPG_SECRET_KEY_PASSWORD }}      
       - name: Publish package to maven
-        run: mvn -B --no-transfer-progress -Dgpg.passphrase=${{ secrets.OSSRH_GPG_SECRET_KEY_PASSWORD }} deploy
+        run: mvn -B --no-transfer-progress -P sign -Dgpg.passphrase=${{ secrets.OSSRH_GPG_SECRET_KEY_PASSWORD }} deploy
         env:
           MAVEN_USERNAME: ${{ secrets.OSSRH_USERNAME }}
           MAVEN_PASSWORD: ${{ secrets.OSSRH_TOKEN }}

--- a/pom.xml
+++ b/pom.xml
@@ -70,13 +70,19 @@
                                 <goals>
                                     <goal>sign</goal>
                                 </goals>
+                                <configuration>
+                                    <gpgArguments>
+                                        <arg>--pinentry-mode</arg>
+                                        <arg>loopback</arg>
+                                    </gpgArguments>
+                                </configuration>
                             </execution>
                         </executions>
                     </plugin>
                     <plugin>
                         <groupId>org.sonatype.plugins</groupId>
                         <artifactId>nexus-staging-maven-plugin</artifactId>
-                        <version>1.6.8</version>
+                        <version>1.6.13</version>
                         <extensions>true</extensions>
                         <configuration>
                             <serverId>ossrh-fidesmo</serverId>

--- a/spotbugs.xml
+++ b/spotbugs.xml
@@ -7,4 +7,8 @@
   <Match>
     <Bug pattern="RCN_REDUNDANT_NULLCHECK_OF_NONNULL_VALUE"/>
   </Match>
+  <Match>
+    <Class name="com.fidesmo.fdsm.Main" />
+    <Bug pattern="UUF_UNUSED_FIELD" />
+  </Match>
 </FindBugsFilter>


### PR DESCRIPTION
Updated publishing configuration: 
* using sign profile that have all the GPG and nexus publishing configuration
* updated GPG settings to do not ask for password from TTY
* Ignoring unused fields in tools main. I think it's little sense in publishing the tool jars and in the future we should remove it from published artifacts.

With updated configuration I was able to finally publish the latest version, it's not yet indexed by search, but is [available](https://repo1.maven.org/maven2/com/fidesmo/fdsm/22.09.19/).