### PR TITLE
Fixes launch4j publishing on release

### DIFF
--- a/tool/pom.xml
+++ b/tool/pom.xml
@@ -65,7 +65,7 @@
                     <plugin>
                         <groupId>com.akathist.maven.plugins.launch4j</groupId>
                         <artifactId>launch4j-maven-plugin</artifactId>
-                        <version>2.2.0</version>
+                        <version>2.3.3</version>
                         <executions>
                             <execution>
                                 <id>fdsm-exe</id>
@@ -82,6 +82,7 @@
                                         <mainClass>com.fidesmo.fdsm.Main</mainClass>
                                     </classPath>
                                     <jre>
+                                        <path>${env.JAVA_HOME}</path>
                                         <minVersion>11.0</minVersion>
                                     </jre>
                                     <versionInfo>


### PR DESCRIPTION
This PR attempts to fix launch4j configuration, as starting from launch4j 3.50 JRE path [is required](https://launch4j.sourceforge.net/docs.html#Configuration_file). The 3.50 version [was published](https://mvnrepository.com/artifact/net.sf.launch4j/launch4j) after the last successfull release and even though we haven't updated the launch4j version ourselves, it seems the plugin takes the latest one automatically. 

Locally the change works, so hope GH Action will like it as well.