### PR TITLE
Fijex JRE runtime path

### DIFF
--- a/tool/pom.xml
+++ b/tool/pom.xml
@@ -82,7 +82,7 @@
                                         <mainClass>com.fidesmo.fdsm.Main</mainClass>
                                     </classPath>
                                     <jre>
-                                        <path>${env.JAVA_HOME}</path>
+                                        <path>%JAVA_HOME%;%PATH%</path>
                                         <minVersion>11.0</minVersion>
                                     </jre>
                                     <versionInfo>


### PR DESCRIPTION
As corrected by @martinpaljak this setting is a runtime path on the client side, not the one used during build. So setting it to defaults that older version of the launch4j was providing.