### PR TITLE
Do not require --app-id and support getting it from environment

### DIFF
--- a/tool/src/main/java/com/fidesmo/fdsm/CommandLineInterface.java
+++ b/tool/src/main/java/com/fidesmo/fdsm/CommandLineInterface.java
@@ -72,7 +72,7 @@ abstract class CommandLineInterface {
     final static protected OptionSpec<String> OPT_UNINSTALL = parser.accepts("uninstall", "Uninstall CAP from card").withRequiredArg().describedAs("CAP file / AID");
 
     final static protected OptionSpec<String> OPT_APP_ID = parser.accepts("app-id", "Application identifier")
-                                                                .requiredIf(OPT_STORE_DATA, OPT_SECURE_APDU, OPT_UNINSTALL, OPT_INSTALL, OPT_UPLOAD, OPT_CLEANUP, OPT_LIST_APPLETS, OPT_FLUSH_APPLETS, OPT_DELETE_APPLET)
+                                                                .availableIf(OPT_STORE_DATA, OPT_SECURE_APDU, OPT_UNINSTALL, OPT_INSTALL, OPT_UPLOAD, OPT_CLEANUP, OPT_LIST_APPLETS, OPT_FLUSH_APPLETS, OPT_DELETE_APPLET)
                                                                 .withRequiredArg().describedAs("appId");
     final static protected OptionSpec<Integer> OPT_QA = parser.accepts("qa", "Run a QA support session").withOptionalArg().ofType(Integer.class).describedAs("QA number");
 
@@ -81,6 +81,9 @@ abstract class CommandLineInterface {
 
     final static String ENV_FIDESMO_API_URL = "FIDESMO_API_URL";
     final static String ENV_FIDESMO_AUTH = "FIDESMO_AUTH";
+
+    final static String ENV_FIDESMO_APPID = "FIDESMO_APPID";
+
     final static String ENV_FIDESMO_DEBUG = "FIDESMO_DEBUG";
 
 
@@ -98,7 +101,7 @@ abstract class CommandLineInterface {
     protected static void inspectEnvironment(OptionSet args) {
         // Authentication
         if (!args.has(OPT_AUTH) && System.getenv().containsKey(ENV_FIDESMO_AUTH)) {
-            System.out.printf("Using $%s for authentication", ENV_FIDESMO_AUTH);
+            System.out.printf("Using $%s for authentication%n", ENV_FIDESMO_AUTH);
             auth = ClientAuthentication.forUserPasswordOrToken(System.getenv(ENV_FIDESMO_AUTH));
         }
         if (args.has(OPT_AUTH)) {

--- a/tool/src/main/java/com/fidesmo/fdsm/Main.java
+++ b/tool/src/main/java/com/fidesmo/fdsm/Main.java
@@ -611,11 +611,14 @@ public class Main extends CommandLineInterface {
     }
 
     private static String getAppId() {
-        if (args.valueOf(OPT_APP_ID) == null) {
-            throw new IllegalArgumentException("Operation requires app-id parameter!");            
+        // Value is required, thus we can safely use valueOf
+        if (args.has(OPT_APP_ID)) {
+            return args.valueOf(OPT_APP_ID);
+        } else if (System.getenv(ENV_FIDESMO_APPID) != null) {
+            return System.getenv(ENV_FIDESMO_APPID);
         } else {
-            return args.valueOf(OPT_APP_ID).toString();
-        }        
+            throw new IllegalArgumentException("Operation requires --app-id or $FIDESMO_APPID");
+        }
     }
 
     private static class FidesmoService {


### PR DESCRIPTION
This makes working interactively from CLI more pleasant. Both appID and authentication can be set in the environment (direnv, ondir etc)