### PR TITLE
Add empty select after checking card info

### DIFF
--- a/library/src/main/java/com/fidesmo/fdsm/FidesmoCard.java
+++ b/library/src/main/java/com/fidesmo/fdsm/FidesmoCard.java
@@ -181,6 +181,7 @@ public class FidesmoCard {
     static final HexBytes getDataCIN = HexBytes.b(new CommandAPDU(0x80, 0xCA, 0x00, 0x45, 0x00).getBytes());
     static final HexBytes selectFidesmoPlatform = HexBytes.b(new CommandAPDU(0x00, 0xA4, 0x04, 0x00, FIDESMO_PLATFORM_AID.getBytes()).getBytes());
     static final HexBytes selectFidesmoBatch = HexBytes.b(new CommandAPDU(0x00, 0xA4, 0x04, 0x00, FIDESMO_BATCH_AID.getBytes()).getBytes());
+    static final HexBytes selectEmpty = HexBytes.b(new CommandAPDU(0x00, 0xA4, 0x00, 0x00, 0x00).getBytes());
 
     public static Map<HexBytes, byte[]> probe(BIBO channel) {
         // preserve order, just for fun
@@ -329,6 +330,14 @@ public class FidesmoCard {
             }
         }
         return true;
+    }
+
+    public byte[] selectEmpty(APDUBIBO channel) {
+        CommandAPDU select = new CommandAPDU(selectEmpty.value());
+        ResponseAPDU response;
+
+        response = channel.transmit(select);
+        return response.getData();
     }
 
     public byte[] getCIN() {

--- a/library/src/main/java/com/fidesmo/fdsm/ServiceDeliverySession.java
+++ b/library/src/main/java/com/fidesmo/fdsm/ServiceDeliverySession.java
@@ -104,6 +104,8 @@ public class ServiceDeliverySession implements Callable<ServiceDeliverySession.D
     }
 
     public DeliveryResult deliver(BIBO bibo, String appId, String serviceId) throws IOException, UnsupportedCallbackException {
+        APDUBIBO apduBibo = new APDUBIBO(bibo);
+        card.selectEmpty(apduBibo);
         // Address #4
         JsonNode deviceInfo = client.rpc(client.getURI(FidesmoApiClient.DEVICES_URL, HexUtils.bin2hex(card.getCIN()), card.getBatchId()));
         byte[] iin = HexUtils.decodeHexString_imp(deviceInfo.get("iin").asText());
@@ -164,9 +166,6 @@ public class ServiceDeliverySession implements Callable<ServiceDeliverySession.D
             deliveryRequest.put("msisdn", userInput.remove("msisdn").getValue());
 
         deliveryRequest.set("fields", mapToJsonNode(userInput));
-
-        APDUBIBO apduBibo = new APDUBIBO(bibo);
-        card.selectEmpty(apduBibo);
 
         JsonNode delivery = client.rpc(client.getURI(FidesmoApiClient.SERVICE_DELIVER_URL), deliveryRequest);
         String sessionId = delivery.get("sessionId").asText();

--- a/library/src/main/java/com/fidesmo/fdsm/ServiceDeliverySession.java
+++ b/library/src/main/java/com/fidesmo/fdsm/ServiceDeliverySession.java
@@ -105,6 +105,7 @@ public class ServiceDeliverySession implements Callable<ServiceDeliverySession.D
 
     public DeliveryResult deliver(BIBO bibo, String appId, String serviceId) throws IOException, UnsupportedCallbackException {
         APDUBIBO apduBibo = new APDUBIBO(bibo);
+        //Reset after checking card info to avoid leaving FPA selected, which prevents some services to be run.
         card.selectEmpty(apduBibo);
         // Address #4
         JsonNode deviceInfo = client.rpc(client.getURI(FidesmoApiClient.DEVICES_URL, HexUtils.bin2hex(card.getCIN()), card.getBatchId()));

--- a/tool/src/main/java/com/fidesmo/fdsm/Main.java
+++ b/tool/src/main/java/com/fidesmo/fdsm/Main.java
@@ -326,6 +326,8 @@ public class Main extends CommandLineInterface {
                     DeliveryUrl delivery = DeliveryUrl.parse(args.valueOf(OPT_RUN));
 
                     if (delivery.isWebSocket()) {
+                        FidesmoCard fidesmoCard = fidesmoMetadata.get();
+                        fidesmoCard.selectEmpty(bibo);
                         boolean success = WsClient.execute(new URI(delivery.getService()), bibo, auth).join().isSuccess();
                         if (!success) {
                             fail("Fail to run a script");


### PR DESCRIPTION
Add empty select after checking card info.

Checking card info perform some selects that may leave the FPA selected, this prevents some services to be run.