### PR TITLE
Slightly improved CLI fields parser

### DIFF
--- a/tool/src/main/java/com/fidesmo/fdsm/Main.java
+++ b/tool/src/main/java/com/fidesmo/fdsm/Main.java
@@ -589,7 +589,7 @@ public class Main extends CommandLineInterface {
 
             for (String pair : fieldPairs) {
                 if (!pair.isEmpty()) {
-                    String[] fieldAndValue = pair.split("=");
+                    String[] fieldAndValue = pair.split("=", 2);
 
                     if (fieldAndValue.length != 2) {
                         throw new IllegalArgumentException("Wrong format for fields pair: " + pair + ". Required: fieldId=fieldValue,");


### PR DESCRIPTION
Fields parser was breaking when specifying complex fields like `field=http://site.com?query=test` because it has two `=` signs in it. This PR fixes that problem